### PR TITLE
tilemaker v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tilemaker = ["server/static/*", "server/static/assets/*"]
 
 [project]
 name = "tilemaker"
-version = "2.5.0"
+version = "3.0.0"
 requires-python = ">=3.10"
 dependencies = [
     "pixell",

--- a/tilemaker/client/simple.py
+++ b/tilemaker/client/simple.py
@@ -15,6 +15,7 @@ def create_sample_metadata(filename: str):
 
     return [
         MapGroup(
+            map_group_id="example-map-group",
             name="Map Group",
             description="Example",
             maps=[

--- a/tilemaker/metadata/core.py
+++ b/tilemaker/metadata/core.py
@@ -6,7 +6,7 @@ import structlog
 from pydantic import BaseModel
 
 from .boxes import Box
-from .definitions import Layer, MapGroup
+from .definitions import Band, Layer, MapGroup
 from .sources import SourceGroup
 
 
@@ -20,6 +20,59 @@ class DataConfiguration(BaseModel):
             map_groups=self.map_groups + other.map_groups,
             boxes=self.boxes + other.boxes,
             source_groups=self.source_groups + other.source_groups,
+        )
+
+    def _match(self, name: str, query: str) -> bool:
+        return query.lower() in name.lower()
+
+    def filter_map_groups(self, authorized_map_groups: list, query: str) -> dict:
+        matched_ids: set[str] = set()
+        filtered_groups = []
+
+        for group in authorized_map_groups:
+            # Group name matches — keep entire subtree intact
+            if self._match(group["name"], query):
+                matched_ids.add(group["map_group_id"])
+                filtered_groups.append(group)
+                continue
+
+            filtered_maps = []
+            for map in group.get("maps", []):
+                # Map name matches — keep entire subtree intact
+                if self._match(map["name"], query):
+                    matched_ids.add(map["map_id"])
+                    filtered_maps.append(map)
+                    continue
+
+                filtered_bands = []
+                for band in map.get("bands", []):
+                    # Band name matches — keep entire subtree intact
+                    if self._match(band["name"], query):
+                        matched_ids.add(band["band_id"])
+                        filtered_bands.append(band)
+                        continue
+
+                    filtered_layers = [
+                        layer
+                        for layer in band.get("layers", [])
+                        if self._match(layer["name"], query)
+                        and matched_ids.add(layer["layer_id"]) is None
+                    ]
+                    if filtered_layers:
+                        filtered_bands.append({**band, "layers": filtered_layers})
+
+                if filtered_bands:
+                    filtered_maps.append({**map, "bands": filtered_bands})
+
+            if filtered_maps:
+                filtered_groups.append({**group, "maps": filtered_maps})
+
+        return {"filtered_map_groups": filtered_groups, "matched_ids": matched_ids}
+
+    @property
+    def bands(self) -> Iterable[Band]:
+        return itertools.chain.from_iterable(
+            map.bands for group in self.map_groups for map in group.maps
         )
 
     @property

--- a/tilemaker/metadata/core.py
+++ b/tilemaker/metadata/core.py
@@ -6,7 +6,7 @@ import structlog
 from pydantic import BaseModel
 
 from .boxes import Box
-from .definitions import Band, Layer, MapGroup
+from .definitions import Band, Layer, LayerWithMenuState, MapGroup, SearchResponse
 from .sources import SourceGroup
 
 
@@ -25,7 +25,9 @@ class DataConfiguration(BaseModel):
     def _match(self, name: str, query: str) -> bool:
         return query.lower() in name.lower()
 
-    def filter_map_groups(self, authorized_map_groups: list, query: str) -> dict:
+    def filter_map_groups(
+        self, authorized_map_groups: list, query: str
+    ) -> SearchResponse:
         matched_ids: set[str] = set()
         filtered_groups = []
 
@@ -67,7 +69,10 @@ class DataConfiguration(BaseModel):
             if filtered_maps:
                 filtered_groups.append({**group, "maps": filtered_maps})
 
-        return {"filtered_map_groups": filtered_groups, "matched_ids": matched_ids}
+        return SearchResponse(
+            filtered_map_groups=filtered_groups,
+            matched_ids=matched_ids,
+        )
 
     @property
     def bands(self) -> Iterable[Band]:
@@ -76,12 +81,18 @@ class DataConfiguration(BaseModel):
         )
 
     @property
-    def layers(self) -> Iterable[Layer]:
-        return itertools.chain.from_iterable(
-            band.layers
+    def layers(self) -> Iterable[LayerWithMenuState]:
+        return (
+            LayerWithMenuState(
+                **layer.model_dump(),
+                map_group_id=group.map_group_id,
+                map_id=map.map_id,
+                band_id=band.band_id,
+            )
             for group in self.map_groups
             for map in group.maps
             for band in map.bands
+            for layer in band.layers
         )
 
     def layer(self, layer_id: str) -> Layer | None:

--- a/tilemaker/metadata/core.py
+++ b/tilemaker/metadata/core.py
@@ -70,8 +70,8 @@ class DataConfiguration(BaseModel):
                 filtered_groups.append({**group, "maps": filtered_maps})
 
         return SearchResponse(
-            filtered_map_groups=filtered_groups,
-            matched_ids=matched_ids,
+            filtered_layer_menu=filtered_groups,
+            matched_ids=list(matched_ids),
         )
 
     @property

--- a/tilemaker/metadata/database.py
+++ b/tilemaker/metadata/database.py
@@ -262,6 +262,7 @@ class DatabaseDataConfiguration:
             description=orm_group.description,
             maps=maps,
             grant=orm_group.grant,
+            map_group_id=orm_group.map_group_id,
         )
 
     def populate_from_config(self, config: "DataConfiguration") -> None:
@@ -286,6 +287,7 @@ class DatabaseDataConfiguration:
                         name=map_group.name,
                         description=map_group.description,
                         grant=map_group.grant,
+                        map_group_id=map_group.map_group_id,
                     )
                     session.add(orm_group)
                     session.flush()

--- a/tilemaker/metadata/database.py
+++ b/tilemaker/metadata/database.py
@@ -160,7 +160,7 @@ class DatabaseDataConfiguration:
                 group_state.maps.append(map_state)
 
         return SearchResponse(
-            filtered_map_groups=list(group_map.values()),
+            filtered_layer_menu=list(group_map.values()),
             matched_ids=list(matched_ids),
         )
 

--- a/tilemaker/metadata/database.py
+++ b/tilemaker/metadata/database.py
@@ -16,9 +16,15 @@ from .boxes import Box
 from .core import DataConfiguration
 from .definitions import (
     Band,
+    BandMenuState,
     Layer,
+    LayerSummary,
+    LayerWithMenuState,
     Map,
     MapGroup,
+    MapGroupMenuState,
+    MapMenuState,
+    SearchResponse,
 )
 from .fits import FITSCombinationLayerProvider, FITSLayerProvider
 from .orm import (
@@ -61,12 +67,102 @@ class DatabaseDataConfiguration:
         """Create all tables in the database."""
         Base.metadata.create_all(self.engine)
 
-    """
-    TODO: Use database queries to filter map groups based on query string
-    """
+    def filter_map_groups(self, _: list, query: str) -> dict:
+        """
+        Use database queries to filter map groups based on user's query string
+        """
+        from sqlalchemy import or_
 
-    def filter_map_groups(self, authorized_map_groups: list, query: str) -> dict:
-        return {"filtered_map_groups": [], "matched_ids": []}
+        pattern = f"%{query}%"
+
+        with self.session_maker() as session:
+            hits = (
+                session.query(LayerORM, BandORM, MapORM, MapGroupORM)
+                .join(BandORM, LayerORM.band_id == BandORM.id)
+                .join(MapORM, BandORM.map_id == MapORM.id)
+                .join(MapGroupORM, MapORM.map_group_id == MapGroupORM.id)
+                .filter(
+                    or_(
+                        MapGroupORM.name.ilike(pattern),
+                        MapORM.name.ilike(pattern),
+                        BandORM.name.ilike(pattern),
+                        LayerORM.name.ilike(pattern),
+                    )
+                )
+                .all()
+            )
+
+        matched_ids: set[str] = set()
+
+        # Build the menu-state hierarchy purely from hit rows
+        # using ordered dicts to deduplicate by ID
+        group_map: dict[str, MapGroupMenuState] = {}
+        map_map: dict[str, MapMenuState] = {}
+        band_map: dict[tuple, BandMenuState] = {}
+
+        for layer_orm, band_orm, map_orm, group_orm in hits:
+            # Track what level matched to determine matched_ids
+            if query.lower() in group_orm.name.lower():
+                matched_ids.add(group_orm.map_group_id)
+            elif query.lower() in map_orm.name.lower():
+                matched_ids.add(map_orm.map_id)
+            elif query.lower() in band_orm.name.lower():
+                matched_ids.add(band_orm.band_id)
+            else:
+                matched_ids.add(layer_orm.layer_id)
+
+            layer_summary = LayerSummary(
+                layer_id=layer_orm.layer_id,
+                name=layer_orm.name,
+                description=layer_orm.description,
+                grant=layer_orm.grant,
+            )
+
+            band_key = (map_orm.map_id, band_orm.band_id)
+            if band_key not in band_map:
+                band_map[band_key] = BandMenuState(
+                    band_id=band_orm.band_id,
+                    name=band_orm.name,
+                    description=band_orm.description or "",
+                    grant=band_orm.grant,
+                    layers=[],
+                )
+
+            if map_orm.map_id not in map_map:
+                map_map[map_orm.map_id] = MapMenuState(
+                    map_id=map_orm.map_id,
+                    name=map_orm.name,
+                    description=map_orm.description or "",
+                    grant=map_orm.grant,
+                    bands=[],
+                )
+
+            if group_orm.map_group_id not in group_map:
+                group_map[group_orm.map_group_id] = MapGroupMenuState(
+                    map_group_id=group_orm.map_group_id,
+                    name=group_orm.name,
+                    description=group_orm.description or "",
+                    grant=group_orm.grant,
+                    maps=[],
+                )
+
+            # Wire up the hierarchy
+            band_state = band_map[band_key]
+            if layer_summary not in band_state.layers:
+                band_state.layers.append(layer_summary)
+
+            map_state = map_map[map_orm.map_id]
+            if band_state not in map_state.bands:
+                map_state.bands.append(band_state)
+
+            group_state = group_map[group_orm.map_group_id]
+            if map_state not in group_state.maps:
+                group_state.maps.append(map_state)
+
+        return SearchResponse(
+            filtered_map_groups=list(group_map.values()),
+            matched_ids=list(matched_ids),
+        )
 
     @property
     def map_groups(self) -> list[MapGroup]:
@@ -102,13 +198,19 @@ class DatabaseDataConfiguration:
         )
 
     @property
-    def layers(self) -> Iterable[Layer]:
+    def layers(self) -> Iterable[LayerWithMenuState]:
         """Retrieve all layers from the database."""
-        return itertools.chain.from_iterable(
-            band.layers
+        return (
+            LayerWithMenuState(
+                **layer.model_dump(),
+                map_group_id=group.map_group_id,
+                map_id=map.map_id,
+                band_id=band.band_id,
+            )
             for group in self.map_groups
             for map in group.maps
             for band in map.bands
+            for layer in band.layers
         )
 
     def layer(self, layer_id: str) -> Layer | None:

--- a/tilemaker/metadata/database.py
+++ b/tilemaker/metadata/database.py
@@ -61,6 +61,13 @@ class DatabaseDataConfiguration:
         """Create all tables in the database."""
         Base.metadata.create_all(self.engine)
 
+    """
+    TODO: Use database queries to filter map groups based on query string
+    """
+
+    def filter_map_groups(self, authorized_map_groups: list, query: str) -> dict:
+        return {"filtered_map_groups": [], "matched_ids": []}
+
     @property
     def map_groups(self) -> list[MapGroup]:
         """Retrieve all map groups from the database."""
@@ -86,6 +93,13 @@ class DatabaseDataConfiguration:
                 self._orm_to_source_group(session, orm_group)
                 for orm_group in orm_groups
             ]
+
+    @property
+    def bands(self) -> Iterable[Band]:
+        """Retrieve all bands from the database."""
+        return itertools.chain.from_iterable(
+            map.bands for group in self.map_groups for map in group.maps
+        )
 
     @property
     def layers(self) -> Iterable[Layer]:

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -127,7 +127,7 @@ class BandBase(AuthenticatedModel):
     band_id: str
     name: str
     description: str
-    
+
 
 class Band(BandBase):
     layers: list[Layer]
@@ -152,9 +152,9 @@ class MapMenuState(MapBase):
 
 
 class MapGroupBase(AuthenticatedModel):
-  map_group_id: str
-  name: str
-  description: str 
+    map_group_id: str
+    name: str
+    description: str
 
 
 class MapGroup(MapGroupBase):

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -117,6 +117,12 @@ class Layer(LayerSummary):
             self.tile_size, self.number_of_levels = self.provider.calculate_tile_size()
 
 
+class LayerWithMenuState(Layer):
+    map_group_id: str
+    map_id: str
+    band_id: str
+
+
 class BandBase(AuthenticatedModel):
     band_id: str
     name: str
@@ -174,3 +180,8 @@ class LayerDefault(AuthenticatedModel):
     default_map_group_id: str
     default_map_id: str
     default_band_id: str
+
+
+class SearchResponse(AuthenticatedModel):
+    filtered_layer_menu: list[MapGroupMenuState]
+    matched_ids: list[str]

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -81,11 +81,13 @@ class AuthenticatedModel(BaseModel):
         return self.grant is None or self.grant in grants
 
 
-class Layer(AuthenticatedModel):
+class LayerSummary(AuthenticatedModel):
     layer_id: str
     name: str
     description: str | None = None
 
+
+class Layer(LayerSummary):
     provider: FITSLayerProvider | FITSCombinationLayerProvider
 
     bounding_left: float | None = None
@@ -115,26 +117,52 @@ class Layer(AuthenticatedModel):
             self.tile_size, self.number_of_levels = self.provider.calculate_tile_size()
 
 
-class Band(AuthenticatedModel):
+class LayerDefault(AuthenticatedModel):
+    map_group_id: str
+    map_id: str
+    band_id: str
+    layer: Layer
+
+
+class BandBase(AuthenticatedModel):
     band_id: str
     name: str
     description: str
 
+
+class BandSummary(BandBase):
+    layer_ids: list[str]
+    
+
+class Band(BandBase):
     layers: list[Layer]
 
 
-class Map(AuthenticatedModel):
+class MapBase(AuthenticatedModel):
     map_id: str
     name: str
     description: str
 
+
+class MapSummary(MapBase):
+    band_ids: list[str]
+
+
+class Map(MapBase):
     bands: list[Band]
 
 
-class MapGroup(AuthenticatedModel):
-    name: str
-    description: str
+class MapGroupBase(AuthenticatedModel):
+  map_group_id: str
+  name: str
+  description: str 
 
+
+class MapGroupSummary(MapGroupBase):
+  map_ids: list[str]
+
+
+class MapGroup(MapGroupBase):
     maps: list[Map]
 
     def get_layer(self, layer_id: str) -> Layer | None:

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -117,25 +117,18 @@ class Layer(LayerSummary):
             self.tile_size, self.number_of_levels = self.provider.calculate_tile_size()
 
 
-class LayerDefault(AuthenticatedModel):
-    map_group_id: str
-    map_id: str
-    band_id: str
-    layer: Layer
-
-
 class BandBase(AuthenticatedModel):
     band_id: str
     name: str
     description: str
-
-
-class BandSummary(BandBase):
-    layer_ids: list[str]
     
 
 class Band(BandBase):
     layers: list[Layer]
+
+
+class BandMenuState(BandBase):
+    layers: list[LayerSummary]
 
 
 class MapBase(AuthenticatedModel):
@@ -144,22 +137,18 @@ class MapBase(AuthenticatedModel):
     description: str
 
 
-class MapSummary(MapBase):
-    band_ids: list[str]
-
-
 class Map(MapBase):
     bands: list[Band]
+
+
+class MapMenuState(MapBase):
+    bands: list[BandMenuState]
 
 
 class MapGroupBase(AuthenticatedModel):
   map_group_id: str
   name: str
   description: str 
-
-
-class MapGroupSummary(MapGroupBase):
-  map_ids: list[str]
 
 
 class MapGroup(MapGroupBase):
@@ -173,3 +162,15 @@ class MapGroup(MapGroupBase):
                         return layer
 
         return None
+
+
+class MapGroupMenuState(MapGroupBase):
+    maps: list[MapMenuState]
+
+
+class LayerDefault(AuthenticatedModel):
+    layer: Layer
+    default_layer_menu: list[MapGroupMenuState]
+    default_map_group_id: str
+    default_map_id: str
+    default_band_id: str

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -175,11 +175,8 @@ class MapGroupMenuState(MapGroupBase):
 
 
 class LayerDefault(AuthenticatedModel):
-    layer: Layer | None
+    layer: LayerWithMenuState | None
     default_layer_menu: list[MapGroupMenuState]
-    default_map_group_id: str | None
-    default_map_id: str | None
-    default_band_id: str | None
 
 
 class SearchResponse(AuthenticatedModel):

--- a/tilemaker/metadata/definitions.py
+++ b/tilemaker/metadata/definitions.py
@@ -175,11 +175,11 @@ class MapGroupMenuState(MapGroupBase):
 
 
 class LayerDefault(AuthenticatedModel):
-    layer: Layer
+    layer: Layer | None
     default_layer_menu: list[MapGroupMenuState]
-    default_map_group_id: str
-    default_map_id: str
-    default_band_id: str
+    default_map_group_id: str | None
+    default_map_id: str | None
+    default_band_id: str | None
 
 
 class SearchResponse(AuthenticatedModel):

--- a/tilemaker/metadata/generation.py
+++ b/tilemaker/metadata/generation.py
@@ -78,9 +78,9 @@ def map_group_from_fits(
 
     return MapGroup(
         map_group_id=f"map-group-{uuid.uuid4()}",
-        name="Auto-Populated", 
-        description="No description provided", 
-        maps=maps
+        name="Auto-Populated",
+        description="No description provided",
+        maps=maps,
     )
 
 

--- a/tilemaker/metadata/generation.py
+++ b/tilemaker/metadata/generation.py
@@ -3,6 +3,7 @@ Create a set of metadata directly from a provider.
 """
 
 import os
+import uuid
 from hashlib import md5
 from pathlib import Path
 from typing import Any, Literal
@@ -76,7 +77,10 @@ def map_group_from_fits(
         )
 
     return MapGroup(
-        name="Auto-Populated", description="No description provided", maps=maps
+        map_group_id=f"map-group-{uuid.uuid4()}",
+        name="Auto-Populated", 
+        description="No description provided", 
+        maps=maps
     )
 
 

--- a/tilemaker/metadata/orm.py
+++ b/tilemaker/metadata/orm.py
@@ -21,6 +21,7 @@ class MapGroupORM(Base):
     __tablename__ = "map_groups"
 
     id = Column(Integer, primary_key=True)
+    map_group_id = Column(String, unique=True, nullable=False)
     name = Column(String, nullable=False)
     description = Column(String)
     grant = Column(String)

--- a/tilemaker/server/app.py
+++ b/tilemaker/server/app.py
@@ -12,12 +12,12 @@ from fastapi.staticfiles import StaticFiles
 from ..settings import settings
 from .analysis import analysis_router
 from .auth import setup_auth
+from .bands import bands_router
 from .highlights import highlights_router
 from .histogram import histogram_router
+from .layers import layers_router
 from .map_groups import map_groups_router
 from .maps import maps_router
-from .bands import bands_router
-from .layers import layers_router
 from .search import search_router
 from .sources import sources_router
 

--- a/tilemaker/server/app.py
+++ b/tilemaker/server/app.py
@@ -14,7 +14,10 @@ from .analysis import analysis_router
 from .auth import setup_auth
 from .highlights import highlights_router
 from .histogram import histogram_router
+from .map_groups import map_groups_router
 from .maps import maps_router
+from .bands import bands_router
+from .layers import layers_router
 from .sources import sources_router
 
 
@@ -61,7 +64,10 @@ app = setup_auth(app)
 app.include_router(highlights_router)
 app.include_router(histogram_router)
 app.include_router(sources_router)
+app.include_router(map_groups_router)
 app.include_router(maps_router)
+app.include_router(bands_router)
+app.include_router(layers_router)
 app.include_router(analysis_router)
 
 if settings.serve_frontend:

--- a/tilemaker/server/app.py
+++ b/tilemaker/server/app.py
@@ -18,6 +18,7 @@ from .map_groups import map_groups_router
 from .maps import maps_router
 from .bands import bands_router
 from .layers import layers_router
+from .search import search_router
 from .sources import sources_router
 
 
@@ -68,6 +69,7 @@ app.include_router(map_groups_router)
 app.include_router(maps_router)
 app.include_router(bands_router)
 app.include_router(layers_router)
+app.include_router(search_router)
 app.include_router(analysis_router)
 
 if settings.serve_frontend:

--- a/tilemaker/server/bands.py
+++ b/tilemaker/server/bands.py
@@ -2,12 +2,12 @@
 Endpoint for summary data of a band's layers
 """
 
-from tilemaker.metadata.definitions import LayerSummary
-
 from fastapi import (
     APIRouter,
     Request,
 )
+
+from tilemaker.metadata.definitions import LayerSummary
 
 bands_router = APIRouter(prefix="/bands", tags=["List of Bands"])
 
@@ -16,16 +16,13 @@ bands_router = APIRouter(prefix="/bands", tags=["List of Bands"])
     "/{band_id}/layers",
     response_model=list[LayerSummary],
     summary="Get the list of layer summaries associated with a Band.",
-    description="Retrieve a list of LayerSummary objects that belong to a particular Band."
+    description="Retrieve a list of LayerSummary objects that belong to a particular Band.",
 )
-def get_layer_summaries_of_band(
-    band_id: str,
-    request: Request
-):
+def get_layer_summaries_of_band(band_id: str, request: Request):
     for map_group in request.app.config.map_groups:
         for map in map_group.maps:
             for band in map.bands:
-                if (band.band_id == band_id and map_group.auth(request.auth.scopes)):
+                if band.band_id == band_id and map_group.auth(request.auth.scopes):
                     layer_summaries = []
                     for layer in band.layers:
                         layer_summary = LayerSummary(

--- a/tilemaker/server/bands.py
+++ b/tilemaker/server/bands.py
@@ -1,0 +1,38 @@
+"""
+Endpoint for summary data of a band's layers
+"""
+
+from tilemaker.metadata.definitions import BandSummary, LayerSummary
+
+from fastapi import (
+    APIRouter,
+    Request,
+)
+
+bands_router = APIRouter(prefix="/bands", tags=["List of Bands"])
+
+
+@bands_router.get(
+    "/{band_id}/layers",
+    response_model=list[LayerSummary],
+    summary="Get the list of layer summaries associated with a Band.",
+    description="Retrieve a list of LayerSummary objects that belong to a particular Band."
+)
+def get_layer_summaries_of_band(
+    band_id: str,
+    request: Request
+):
+    for map_group in request.app.config.map_groups:
+        for map in map_group.maps:
+            for band in map.bands:
+                if (band.band_id == band_id and map_group.auth(request.auth.scopes)):
+                    layer_summaries = []
+                    for layer in band.layers:
+                        layer_summary = LayerSummary(
+                            layer_id=layer.layer_id,
+                            name=layer.name,
+                            description=layer.description,
+                        )
+                        layer_summaries.append(layer_summary)
+                    return layer_summaries
+    return []

--- a/tilemaker/server/bands.py
+++ b/tilemaker/server/bands.py
@@ -2,7 +2,7 @@
 Endpoint for summary data of a band's layers
 """
 
-from tilemaker.metadata.definitions import BandSummary, LayerSummary
+from tilemaker.metadata.definitions import LayerSummary
 
 from fastapi import (
     APIRouter,

--- a/tilemaker/server/bands.py
+++ b/tilemaker/server/bands.py
@@ -19,17 +19,14 @@ bands_router = APIRouter(prefix="/bands", tags=["List of Bands"])
     description="Retrieve a list of LayerSummary objects that belong to a particular Band.",
 )
 def get_layer_summaries_of_band(band_id: str, request: Request):
-    for map_group in request.app.config.map_groups:
-        for map in map_group.maps:
-            for band in map.bands:
-                if band.band_id == band_id and map_group.auth(request.auth.scopes):
-                    layer_summaries = []
-                    for layer in band.layers:
-                        layer_summary = LayerSummary(
-                            layer_id=layer.layer_id,
-                            name=layer.name,
-                            description=layer.description,
-                        )
-                        layer_summaries.append(layer_summary)
-                    return layer_summaries
-    return []
+    layer_summaries = []
+    for band in request.app.config.bands:
+        if band.band_id == band_id and band.auth(request.auth.scopes):
+            for layer in band.layers:
+                layer_summary = LayerSummary(
+                    layer_id=layer.layer_id,
+                    name=layer.name,
+                    description=layer.description,
+                )
+                layer_summaries.append(layer_summary)
+    return layer_summaries

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -1,6 +1,7 @@
 """
 Endpoint for layer and tile data
 """
+
 import io
 from typing import Literal
 
@@ -14,7 +15,14 @@ from fastapi import (
     Response,
 )
 
-from tilemaker.metadata.definitions import Layer, LayerDefault, MapGroupMenuState, LayerSummary, BandMenuState, MapMenuState, LayerWithMenuState
+from tilemaker.metadata.definitions import (
+    BandMenuState,
+    LayerDefault,
+    LayerSummary,
+    LayerWithMenuState,
+    MapGroupMenuState,
+    MapMenuState,
+)
 from tilemaker.processing.extractor import extract
 from tilemaker.providers.fits import PullableTile
 
@@ -30,11 +38,13 @@ layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
     map groups -> maps -> bands -> layers. Basically, it's the first index
     of each tier until reaching the layer tier.
 """
+
+
 @layers_router.get(
     "/default",
     response_model=LayerDefault,
     summary="Get the hierarchy and layer data for a default layer.",
-    description="Gets layer data needed for the menu and map when first loaded."
+    description="Gets layer data needed for the menu and map when first loaded.",
 )
 def get_default_layer(request: Request):
     default_map_group_id = None
@@ -44,7 +54,7 @@ def get_default_layer(request: Request):
     map_groups = []
 
     for group_idx, map_group in enumerate(request.app.config.map_groups):
-        if map_group.auth(request.auth.scopes) is False: 
+        if map_group.auth(request.auth.scopes) is False:
             continue
 
         maps = []
@@ -69,7 +79,12 @@ def get_default_layer(request: Request):
                                         description=layer.description,
                                     )
                                 )
-                                if group_idx == 0 and map_idx == 0 and band_idx == 0 and layer_idx == 0:
+                                if (
+                                    group_idx == 0
+                                    and map_idx == 0
+                                    and band_idx == 0
+                                    and layer_idx == 0
+                                ):
                                     default_layer = layer
 
                         bands.append(
@@ -77,7 +92,7 @@ def get_default_layer(request: Request):
                                 band_id=band.band_id,
                                 name=band.name,
                                 description=band.description,
-                                layers=layers
+                                layers=layers,
                             )
                         )
 
@@ -86,7 +101,7 @@ def get_default_layer(request: Request):
                         map_id=map.map_id,
                         name=map.name,
                         description=map.description,
-                        bands=bands
+                        bands=bands,
                     )
                 )
 
@@ -95,7 +110,7 @@ def get_default_layer(request: Request):
                     map_group_id=map_group.map_group_id,
                     name=map_group.name,
                     description=map_group.description,
-                    maps=maps
+                    maps=maps,
                 )
             )
         else:
@@ -104,7 +119,7 @@ def get_default_layer(request: Request):
                     map_group_id=map_group.map_group_id,
                     name=map_group.name,
                     description=map_group.description,
-                    maps=[]
+                    maps=[],
                 )
             )
     return LayerDefault(
@@ -113,32 +128,31 @@ def get_default_layer(request: Request):
         default_map_group_id=default_map_group_id,
         default_map_id=default_map_id,
         default_band_id=default_band_id,
-        )
-                
+    )
+
 
 @layers_router.get(
     "/{layer_id}",
     response_model=LayerWithMenuState,
     summary="Get the Layer data.",
-    description="Retrieve the Layer data to be rendered in the mapping client."
+    description="Retrieve the Layer data to be rendered in the mapping client.",
 )
-def get_layer_with_menu_state(
-    layer_id: str,
-    request: Request
-):
+def get_layer_with_menu_state(layer_id: str, request: Request):
     for map_group in request.app.config.map_groups:
         if map_group.auth(request.auth.scopes):
             for map in map_group.maps:
                 for band in map.bands:
                     for layer in band.layers:
-                        if (layer.layer_id == layer_id and map_group.auth(request.auth.scopes)):
+                        if layer.layer_id == layer_id and map_group.auth(
+                            request.auth.scopes
+                        ):
                             return LayerWithMenuState(
                                 **layer.model_dump(),
                                 map_group_id=map_group.map_group_id,
                                 map_id=map.map_id,
                                 band_id=band.band_id,
                             )
-                    
+
 
 @layers_router.get(
     "/{layer_id}/submap/{left}/{right}/{top}/{bottom}/image.{ext}",
@@ -203,7 +217,9 @@ def core_tile_retrieval(
     request: Request,
 ):
     tile, pushables = request.app.tiles.pull(
-        PullableTile(layer_id=layer_id, x=x, y=y, level=level, grants=request.auth.scopes)
+        PullableTile(
+            layer_id=layer_id, x=x, y=y, level=level, grants=request.auth.scopes
+        )
     )
 
     bt.add_task(request.app.tiles.push, pushables)

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -14,7 +14,7 @@ from fastapi import (
     Response,
 )
 
-from tilemaker.metadata.definitions import Layer, LayerDefault, MapGroupMenuState, LayerSummary, BandMenuState, MapMenuState, MapGroupBase
+from tilemaker.metadata.definitions import Layer, LayerDefault, MapGroupMenuState, LayerSummary, BandMenuState, MapMenuState, LayerWithMenuState
 from tilemaker.processing.extractor import extract
 from tilemaker.providers.fits import PullableTile
 
@@ -118,11 +118,11 @@ def get_default_layer(request: Request):
 
 @layers_router.get(
     "/{layer_id}",
-    response_model=Layer,
+    response_model=LayerWithMenuState,
     summary="Get the Layer data.",
     description="Retrieve the Layer data to be rendered in the mapping client."
 )
-def get_layer_summaries_of_band(
+def get_layer_with_menu_state(
     layer_id: str,
     request: Request
 ):
@@ -132,7 +132,12 @@ def get_layer_summaries_of_band(
                 for band in map.bands:
                     for layer in band.layers:
                         if (layer.layer_id == layer_id and map_group.auth(request.auth.scopes)):
-                            return layer
+                            return LayerWithMenuState(
+                                **layer.model_dump(),
+                                map_group_id=map_group.map_group_id,
+                                map_id=map.map_id,
+                                band_id=band.band_id,
+                            )
                     
 
 @layers_router.get(

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -14,7 +14,7 @@ from fastapi import (
     Response,
 )
 
-from tilemaker.metadata.definitions import Layer, LayerDefault
+from tilemaker.metadata.definitions import Layer, LayerDefault, MapGroupMenuState, LayerSummary, BandMenuState, MapMenuState, MapGroupBase
 from tilemaker.processing.extractor import extract
 from tilemaker.providers.fits import PullableTile
 
@@ -25,6 +25,11 @@ renderer = Renderer(format="webp")
 layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
 
 
+"""
+    Naively set to the first layer found according to the structure of
+    map groups -> maps -> bands -> layers. Basically, it's the first index
+    of each tier until reaching the layer tier.
+"""
 @layers_router.get(
     "/default",
     response_model=LayerDefault,
@@ -32,17 +37,83 @@ layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
     description="Gets layer data needed for the menu and map when first loaded."
 )
 def get_default_layer(request: Request):
-    for map_group in request.app.config.map_groups:
-        for map in map_group.maps:
-            for band in map.bands:
-                for layer in band.layers:
-                    default_layer = LayerDefault(
-                        map_group_id=map_group.map_group_id,
+    default_map_group_id = None
+    default_map_id = None
+    default_band_id = None
+    default_layer = None
+    map_groups = []
+
+    for group_idx, map_group in enumerate(request.app.config.map_groups):
+        if map_group.auth(request.auth.scopes) is False: 
+            continue
+
+        maps = []
+
+        if group_idx == 0:
+            default_map_group_id = map_group.map_group_id
+            for map_idx, map in enumerate(map_group.maps):
+                bands = []
+
+                if map_idx == 0:
+                    default_map_id = map.map_id
+                    for band_idx, band in enumerate(map.bands):
+                        layers = []
+
+                        if band_idx == 0:
+                            default_band_id = band.band_id
+                            for layer_idx, layer in enumerate(band.layers):
+                                layers.append(
+                                    LayerSummary(
+                                        layer_id=layer.layer_id,
+                                        name=layer.name,
+                                        description=layer.description,
+                                    )
+                                )
+                                if group_idx == 0 and map_idx == 0 and band_idx == 0 and layer_idx == 0:
+                                    default_layer = layer
+
+                        bands.append(
+                            BandMenuState(
+                                band_id=band.band_id,
+                                name=band.name,
+                                description=band.description,
+                                layers=layers
+                            )
+                        )
+
+                maps.append(
+                    MapMenuState(
                         map_id=map.map_id,
-                        band_id=band.band_id,
-                        layer=layer,
+                        name=map.name,
+                        description=map.description,
+                        bands=bands
                     )
-                    return default_layer
+                )
+
+            map_groups.append(
+                MapGroupMenuState(
+                    map_group_id=map_group.map_group_id,
+                    name=map_group.name,
+                    description=map_group.description,
+                    maps=maps
+                )
+            )
+        else:
+            map_groups.append(
+                MapGroupMenuState(
+                    map_group_id=map_group.map_group_id,
+                    name=map_group.name,
+                    description=map_group.description,
+                    maps=[]
+                )
+            )
+    return LayerDefault(
+        layer=default_layer,
+        default_layer_menu=map_groups,
+        default_map_group_id=default_map_group_id,
+        default_map_id=default_map_id,
+        default_band_id=default_band_id,
+        )
                 
 
 @layers_router.get(
@@ -56,11 +127,12 @@ def get_layer_summaries_of_band(
     request: Request
 ):
     for map_group in request.app.config.map_groups:
-        for map in map_group.maps:
-            for band in map.bands:
-                for layer in band.layers:
-                    if (layer.layer_id == layer_id and map_group.auth(request.auth.scopes)):
-                        return layer
+        if map_group.auth(request.auth.scopes):
+            for map in map_group.maps:
+                for band in map.bands:
+                    for layer in band.layers:
+                        if (layer.layer_id == layer_id and map_group.auth(request.auth.scopes)):
+                            return layer
                     
 
 @layers_router.get(
@@ -179,7 +251,7 @@ def get_tile(
         raise HTTPException(status_code=400, detail="Not an acceptable extension")
 
     numpy_buf = core_tile_retrieval(
-        layer=layer_id,
+        layer_id=layer_id,
         level=level,
         y=y,
         x=x,

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -1,0 +1,195 @@
+"""
+Endpoint for layer and tile data
+"""
+import io
+from typing import Literal
+
+from astropy.io import fits
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+)
+
+from tilemaker.metadata.definitions import Layer, LayerDefault
+from tilemaker.processing.extractor import extract
+from tilemaker.providers.fits import PullableTile
+
+from ..processing.renderer import Renderer, RenderOptions
+
+renderer = Renderer(format="webp")
+
+layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
+
+
+@layers_router.get(
+    "/default",
+    response_model=LayerDefault,
+    summary="Get the hierarchy and layer data for a default layer.",
+    description="Gets layer data needed for the menu and map when first loaded."
+)
+def get_default_layer(request: Request):
+    for map_group in request.app.config.map_groups:
+        for map in map_group.maps:
+            for band in map.bands:
+                for layer in band.layers:
+                    default_layer = LayerDefault(
+                        map_group_id=map_group.map_group_id,
+                        map_id=map.map_id,
+                        band_id=band.band_id,
+                        layer=layer,
+                    )
+                    return default_layer
+                
+
+@layers_router.get(
+    "/{layer_id}",
+    response_model=Layer,
+    summary="Get the Layer data.",
+    description="Retrieve the Layer data to be rendered in the mapping client."
+)
+def get_layer_summaries_of_band(
+    layer_id: str,
+    request: Request
+):
+    for map_group in request.app.config.map_groups:
+        for map in map_group.maps:
+            for band in map.bands:
+                for layer in band.layers:
+                    if (layer.layer_id == layer_id and map_group.auth(request.auth.scopes)):
+                        return layer
+                    
+
+@layers_router.get(
+    "/{layer_id}/submap/{left}/{right}/{top}/{bottom}/image.{ext}",
+    summary="Generate a cut-out of the map.",
+    description="Download and extract (from the base map) a rendered cut-out. Downloads at the full resolution of the underlying map with no additional filter function.",
+)
+def get_submap(
+    layer_id: str,
+    left: float,
+    right: float,
+    top: float,
+    bottom: float,
+    ext: Literal["jpg", "webp", "png", "fits"],
+    request: Request,
+    bt: BackgroundTasks,
+    render_options: RenderOptions = Depends(RenderOptions),
+    show_grid: bool = False,
+):
+    """
+    Get a submap of the specified band.
+    """
+
+    submap, pushables = extract(
+        layer_id=layer_id,
+        left=left,
+        right=right,
+        top=top,
+        bottom=bottom,
+        tiles=request.app.tiles,
+        grants=request.auth.scopes,
+        metadata=request.app.config,
+        show_grid=show_grid,
+    )
+
+    bt.add_task(request.app.tiles.push, pushables)
+
+    if ext == "jpg":
+        with io.BytesIO() as output:
+            renderer.render(output, submap, render_options=render_options)
+            return Response(content=output.getvalue(), media_type="image/jpg")
+    elif ext == "webp":
+        with io.BytesIO() as output:
+            renderer.render(output, submap, render_options=render_options)
+            return Response(content=output.getvalue(), media_type="image/webp")
+    elif ext == "png":
+        with io.BytesIO() as output:
+            renderer.render(output, submap, render_options=render_options)
+            return Response(content=output.getvalue(), media_type="image/png")
+    elif ext == "fits":
+        with io.BytesIO() as output:
+            hdu = fits.PrimaryHDU(submap)
+            hdu.writeto(output)
+            return Response(content=output.getvalue(), media_type="image/fits")
+
+
+def core_tile_retrieval(
+    layer_id: str,
+    level: int,
+    y: int,
+    x: int,
+    bt: BackgroundTasks,
+    request: Request,
+):
+    tile, pushables = request.app.tiles.pull(
+        PullableTile(layer_id=layer_id, x=x, y=y, level=level, grants=request.auth.scopes)
+    )
+
+    bt.add_task(request.app.tiles.push, pushables)
+
+    return tile.data
+
+
+@layers_router.get(
+    "/{layer_id}/{level}/{y}/{x}/tile.{ext}",
+    summary="Retrieve an individual tile.",
+    description="Individual tiles are hosted at a layer level, with them having three axes: `level`, `y`, and `x`. We support extensions of 'png', 'webp', and 'jpg'.",
+)
+def get_tile(
+    layer_id: str,
+    level: int,
+    y: int,
+    x: int,
+    ext: str,
+    request: Request,
+    bt: BackgroundTasks,
+    render_options: RenderOptions = Depends(RenderOptions),
+):
+    """
+    Grab an individual tile. This should be very fast, because we use
+    a composite primary key for band, level, x, and y.
+
+    Supported extensions:
+    - jpg
+    - webp
+    - png
+
+    Note: This does not support FITS tiles, as they are not
+    typically used for rendering. If you need FITS images, please
+    use the `/maps/{map}/{band}/submap/{left}/{right}/{top}/{bottom}/image.fits`
+    endpoint instead.
+    """
+
+    if render_options.flip:
+        # Flipping is really a reconfiguration of -180 < RA < 180 to 360 < RA < 0;
+        # it's a card-folding operation.
+        if level != 0:
+            # Level of zero requires no flipping apart from at the tile level.
+            midpoint = 2 ** (level)
+            if x < midpoint:
+                x = (2 ** (level) - 1) - x
+            else:
+                x = (2 ** (level) - 1) - (x - midpoint) + midpoint
+
+    if ext not in ["jpg", "webp", "png"]:
+        raise HTTPException(status_code=400, detail="Not an acceptable extension")
+
+    numpy_buf = core_tile_retrieval(
+        layer=layer_id,
+        level=level,
+        y=y,
+        x=x,
+        request=request,
+        bt=bt,
+    )
+
+    if numpy_buf is None:
+        raise HTTPException(status_code=404, detail="Tile not found")
+
+    with io.BytesIO() as output:
+        renderer.render(output, numpy_buf, render_options=render_options)
+        return Response(content=output.getvalue(), media_type=f"image/{ext}")

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -132,20 +132,9 @@ def get_default_layer(request: Request):
     description="Retrieve the Layer data to be rendered in the mapping client.",
 )
 def get_layer_with_menu_state(layer_id: str, request: Request):
-    for map_group in request.app.config.map_groups:
-        if map_group.auth(request.auth.scopes):
-            for map in map_group.maps:
-                for band in map.bands:
-                    for layer in band.layers:
-                        if layer.layer_id == layer_id and map_group.auth(
-                            request.auth.scopes
-                        ):
-                            return LayerWithMenuState(
-                                **layer.model_dump(),
-                                map_group_id=map_group.map_group_id,
-                                map_id=map.map_id,
-                                band_id=band.band_id,
-                            )
+    for layer in request.app.config.layers:
+        if layer.layer_id == layer_id and layer.auth(request.auth.scopes):
+            return layer
 
 
 @layers_router.get(

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -56,16 +56,18 @@ def get_default_layer(request: Request):
         return LayerDefault(
             layer=None,
             default_layer_menu=[],
-            default_map_group_id=None,
-            default_map_id=None,
-            default_band_id=None,
         )
 
     # Otherwise, set defaults to first index at each level
     default_map_group = authorized_map_groups[0]
     default_map = default_map_group.maps[0]
     default_band = default_map.bands[0]
-    default_layer = default_band.layers[0]
+    default_layer = LayerWithMenuState(
+        **default_band.layers[0].model_dump(),
+        map_group_id=default_map_group.map_group_id,
+        map_id=default_map.map_id,
+        band_id=default_band.band_id,
+    )
 
     # Make layer summaries for all the default band's layers
     default_layer_summaries = [
@@ -120,9 +122,6 @@ def get_default_layer(request: Request):
     return LayerDefault(
         layer=default_layer,
         default_layer_menu=default_map_groups,
-        default_map_group_id=default_map_group.map_group_id,
-        default_map_id=default_map.map_id,
-        default_band_id=default_band.band_id,
     )
 
 

--- a/tilemaker/server/layers.py
+++ b/tilemaker/server/layers.py
@@ -34,9 +34,9 @@ layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
 
 
 """
-    Naively set to the first layer found according to the structure of
-    map groups -> maps -> bands -> layers. Basically, it's the first index
-    of each tier until reaching the layer tier.
+    Sets default layer to the first layer found after filtering for auth status, i.e.
+    auth_map_groups[0].maps[0].bands[0].layers[0]. Also creates a menu state for the
+    client to render an initial layer menu.
 """
 
 
@@ -47,87 +47,82 @@ layers_router = APIRouter(prefix="/layers", tags=["Layers and Tiles"])
     description="Gets layer data needed for the menu and map when first loaded.",
 )
 def get_default_layer(request: Request):
-    default_map_group_id = None
-    default_map_id = None
-    default_band_id = None
-    default_layer = None
-    map_groups = []
+    authorized_map_groups = list(
+        filter(lambda x: x.auth(request.auth.scopes), request.app.config.map_groups)
+    )
 
-    for group_idx, map_group in enumerate(request.app.config.map_groups):
-        if map_group.auth(request.auth.scopes) is False:
-            continue
+    # Return early because we have no default layer nor menu state
+    if not authorized_map_groups:
+        return LayerDefault(
+            layer=None,
+            default_layer_menu=[],
+            default_map_group_id=None,
+            default_map_id=None,
+            default_band_id=None,
+        )
 
-        maps = []
+    # Otherwise, set defaults to first index at each level
+    default_map_group = authorized_map_groups[0]
+    default_map = default_map_group.maps[0]
+    default_band = default_map.bands[0]
+    default_layer = default_band.layers[0]
 
-        if group_idx == 0:
-            default_map_group_id = map_group.map_group_id
-            for map_idx, map in enumerate(map_group.maps):
-                bands = []
+    # Make layer summaries for all the default band's layers
+    default_layer_summaries = [
+        LayerSummary(
+            layer_id=layer.layer_id, name=layer.name, description=layer.description
+        )
+        for layer in default_band.layers
+    ]
 
-                if map_idx == 0:
-                    default_map_id = map.map_id
-                    for band_idx, band in enumerate(map.bands):
-                        layers = []
-
-                        if band_idx == 0:
-                            default_band_id = band.band_id
-                            for layer_idx, layer in enumerate(band.layers):
-                                layers.append(
-                                    LayerSummary(
-                                        layer_id=layer.layer_id,
-                                        name=layer.name,
-                                        description=layer.description,
-                                    )
-                                )
-                                if (
-                                    group_idx == 0
-                                    and map_idx == 0
-                                    and band_idx == 0
-                                    and layer_idx == 0
-                                ):
-                                    default_layer = layer
-
-                        bands.append(
-                            BandMenuState(
-                                band_id=band.band_id,
-                                name=band.name,
-                                description=band.description,
-                                layers=layers,
-                            )
-                        )
-
-                maps.append(
-                    MapMenuState(
-                        map_id=map.map_id,
-                        name=map.name,
-                        description=map.description,
-                        bands=bands,
-                    )
-                )
-
-            map_groups.append(
-                MapGroupMenuState(
-                    map_group_id=map_group.map_group_id,
-                    name=map_group.name,
-                    description=map_group.description,
-                    maps=maps,
-                )
+    # Add the default_layer_summaries only to the default band; otherwise, assign an empty list
+    default_band_summaries = []
+    for band in default_map.bands:
+        default_band_summaries.append(
+            BandMenuState(
+                band_id=band.band_id,
+                name=band.name,
+                description=band.description,
+                layers=default_layer_summaries
+                if band.band_id == default_band.band_id
+                else [],
             )
-        else:
-            map_groups.append(
-                MapGroupMenuState(
-                    map_group_id=map_group.map_group_id,
-                    name=map_group.name,
-                    description=map_group.description,
-                    maps=[],
-                )
+        )
+
+    # Add the default_band_summaries only to the default map; otherwise, assign an empty list
+    default_map_summaries = []
+    for map in default_map_group.maps:
+        default_map_summaries.append(
+            MapMenuState(
+                map_id=map.map_id,
+                name=map.name,
+                description=map.description,
+                bands=default_band_summaries
+                if map.map_id == default_map.map_id
+                else [],
             )
+        )
+
+    # Add the default_map_summaries only to the default map group; otherwise, assign an empty list
+    default_map_groups = []
+    for map_group in authorized_map_groups:
+        default_map_groups.append(
+            MapGroupMenuState(
+                map_group_id=map_group.map_group_id,
+                name=map_group.name,
+                description=map_group.description,
+                maps=default_map_summaries
+                if map_group.map_group_id == default_map_group.map_group_id
+                else [],
+            )
+        )
+
     return LayerDefault(
         layer=default_layer,
-        default_layer_menu=map_groups,
-        default_map_group_id=default_map_group_id,
-        default_map_id=default_map_id,
-        default_band_id=default_band_id,
+        default_layer_menu=default_map_groups,
+        default_map_group_id=default_map_group.map_group_id,
+        default_map_id=default_map.map_id,
+        default_band_id=default_band.band_id,
     )
 
 

--- a/tilemaker/server/map_groups.py
+++ b/tilemaker/server/map_groups.py
@@ -2,12 +2,12 @@
 Endpoints for getting list of map group summaries and a list of a map group's map summaries.
 """
 
-from tilemaker.metadata.definitions import MapGroupBase, MapBase
-
 from fastapi import (
     APIRouter,
     Request,
 )
+
+from tilemaker.metadata.definitions import MapBase, MapGroupBase
 
 map_groups_router = APIRouter(prefix="/map-groups", tags=["List of Map Groups"])
 
@@ -16,12 +16,12 @@ map_groups_router = APIRouter(prefix="/map-groups", tags=["List of Map Groups"])
     "",
     response_model=list[MapGroupBase],
     summary="Get the list of map group summaries.",
-    description="Retrieve a list of MapGroupSummary objects."
+    description="Retrieve a list of MapGroupSummary objects.",
 )
 def get_map_group_summaries(request: Request):
     map_group_summaries = []
     for x in request.app.config.map_groups:
-        if (x.auth(request.auth.scopes)):
+        if x.auth(request.auth.scopes):
             map_group_summary = MapGroupBase(
                 map_group_id=x.map_group_id,
                 name=x.name,
@@ -36,15 +36,14 @@ def get_map_group_summaries(request: Request):
     "/{map_group_id}/maps",
     response_model=list[MapBase],
     summary="Get the list of map summaries associated with a Map Group.",
-    description="Retrieve a list of MapSummary objects that belong to a particular Map Group."
+    description="Retrieve a list of MapSummary objects that belong to a particular Map Group.",
 )
-def get_map_summaries_of_map_group(
-    map_group_id: str,
-    request: Request
-):
+def get_map_summaries_of_map_group(map_group_id: str, request: Request):
     map_summaries = []
     for map_group in request.app.config.map_groups:
-        if (map_group.map_group_id == map_group_id and map_group.auth(request.auth.scopes)):
+        if map_group.map_group_id == map_group_id and map_group.auth(
+            request.auth.scopes
+        ):
             for map in map_group.maps:
                 map_summary = MapBase(
                     map_id=map.map_id,

--- a/tilemaker/server/map_groups.py
+++ b/tilemaker/server/map_groups.py
@@ -1,0 +1,57 @@
+"""
+Endpoints for getting list of map group summaries and a list of a map group's map summaries.
+"""
+
+from tilemaker.metadata.definitions import MapGroupSummary, MapSummary
+
+from fastapi import (
+    APIRouter,
+    Request,
+)
+
+map_groups_router = APIRouter(prefix="/map-groups", tags=["List of Map Groups"])
+
+
+@map_groups_router.get(
+    "",
+    response_model=list[MapGroupSummary],
+    summary="Get the list of map group summaries.",
+    description="Retrieve a list of MapGroupSummary objects."
+)
+def get_map_group_summaries(request: Request):
+    map_group_summaries = []
+    for x in request.app.config.map_groups:
+        if (x.auth(request.auth.scopes)):
+            map_group_summary = MapGroupSummary(
+                map_group_id=x.map_group_id,
+                name=x.name,
+                description=x.description,
+                map_ids=[map.map_id for map in x.maps]
+            )
+            map_group_summaries.append(map_group_summary)
+
+    return map_group_summaries
+
+
+@map_groups_router.get(
+    "/{map_group_id}/maps",
+    response_model=list[MapSummary],
+    summary="Get the list of map summaries associated with a Map Group.",
+    description="Retrieve a list of MapSummary objects that belong to a particular Map Group."
+)
+def get_map_summaries_of_map_group(
+    map_group_id: str,
+    request: Request
+):
+    map_summaries = []
+    for map_group in request.app.config.map_groups:
+        if (map_group.map_group_id == map_group_id and map_group.auth(request.auth.scopes)):
+            for map in map_group.maps:
+                map_summary = MapSummary(
+                    map_id=map.map_id,
+                    name=map.name,
+                    description=map.description,
+                    band_ids=[band.band_id for band in map.bands]
+                )
+                map_summaries.append(map_summary)
+    return map_summaries

--- a/tilemaker/server/map_groups.py
+++ b/tilemaker/server/map_groups.py
@@ -2,7 +2,7 @@
 Endpoints for getting list of map group summaries and a list of a map group's map summaries.
 """
 
-from tilemaker.metadata.definitions import MapGroupSummary, MapSummary
+from tilemaker.metadata.definitions import MapGroupBase, MapBase
 
 from fastapi import (
     APIRouter,
@@ -14,7 +14,7 @@ map_groups_router = APIRouter(prefix="/map-groups", tags=["List of Map Groups"])
 
 @map_groups_router.get(
     "",
-    response_model=list[MapGroupSummary],
+    response_model=list[MapGroupBase],
     summary="Get the list of map group summaries.",
     description="Retrieve a list of MapGroupSummary objects."
 )
@@ -22,11 +22,10 @@ def get_map_group_summaries(request: Request):
     map_group_summaries = []
     for x in request.app.config.map_groups:
         if (x.auth(request.auth.scopes)):
-            map_group_summary = MapGroupSummary(
+            map_group_summary = MapGroupBase(
                 map_group_id=x.map_group_id,
                 name=x.name,
                 description=x.description,
-                map_ids=[map.map_id for map in x.maps]
             )
             map_group_summaries.append(map_group_summary)
 
@@ -35,7 +34,7 @@ def get_map_group_summaries(request: Request):
 
 @map_groups_router.get(
     "/{map_group_id}/maps",
-    response_model=list[MapSummary],
+    response_model=list[MapBase],
     summary="Get the list of map summaries associated with a Map Group.",
     description="Retrieve a list of MapSummary objects that belong to a particular Map Group."
 )
@@ -47,11 +46,10 @@ def get_map_summaries_of_map_group(
     for map_group in request.app.config.map_groups:
         if (map_group.map_group_id == map_group_id and map_group.auth(request.auth.scopes)):
             for map in map_group.maps:
-                map_summary = MapSummary(
+                map_summary = MapBase(
                     map_id=map.map_id,
                     name=map.name,
                     description=map.description,
-                    band_ids=[band.band_id for band in map.bands]
                 )
                 map_summaries.append(map_summary)
     return map_summaries

--- a/tilemaker/server/maps.py
+++ b/tilemaker/server/maps.py
@@ -2,13 +2,7 @@
 Endpoints for maps.
 """
 
-import io
-from typing import Literal
-
-from fastapi import (
-    APIRouter,
-    Request
-)
+from fastapi import APIRouter, Request
 
 from tilemaker.metadata.definitions import BandBase
 
@@ -19,15 +13,12 @@ maps_router = APIRouter(prefix="/maps", tags=["Maps and Tiles"])
     "/{map_id}/bands",
     response_model=list[BandBase],
     summary="Get the list of band summaries associated with a Map.",
-    description="Retrieve a list of BandSummary objects that belong to a particular Map."
+    description="Retrieve a list of BandSummary objects that belong to a particular Map.",
 )
-def get_layer_summaries_of_band(
-    map_id: str,
-    request: Request
-):
+def get_layer_summaries_of_band(map_id: str, request: Request):
     for map_group in request.app.config.map_groups:
         for map in map_group.maps:
-            if (map.map_id == map_id and map_group.auth(request.auth.scopes)):
+            if map.map_id == map_id and map_group.auth(request.auth.scopes):
                 for band in map.bands:
                     band_summaries = []
                     band_summary = BandBase(

--- a/tilemaker/server/maps.py
+++ b/tilemaker/server/maps.py
@@ -10,14 +10,14 @@ from fastapi import (
     Request
 )
 
-from tilemaker.metadata.definitions import BandSummary
+from tilemaker.metadata.definitions import BandBase
 
 maps_router = APIRouter(prefix="/maps", tags=["Maps and Tiles"])
 
 
 @maps_router.get(
     "/{map_id}/bands",
-    response_model=list[BandSummary],
+    response_model=list[BandBase],
     summary="Get the list of band summaries associated with a Map.",
     description="Retrieve a list of BandSummary objects that belong to a particular Map."
 )
@@ -30,11 +30,10 @@ def get_layer_summaries_of_band(
             if (map.map_id == map_id and map_group.auth(request.auth.scopes)):
                 for band in map.bands:
                     band_summaries = []
-                    band_summary = BandSummary(
+                    band_summary = BandBase(
                         band_id=band.band_id,
                         name=band.name,
                         description=band.description,
-                        layer_ids=[layer.layer_id for layer in band.layers]
                     )
                     band_summaries.append(band_summary)
                 return band_summaries

--- a/tilemaker/server/maps.py
+++ b/tilemaker/server/maps.py
@@ -5,164 +5,37 @@ Endpoints for maps.
 import io
 from typing import Literal
 
-from astropy.io import fits
 from fastapi import (
     APIRouter,
-    BackgroundTasks,
-    Depends,
-    HTTPException,
-    Request,
-    Response,
+    Request
 )
 
-from tilemaker.metadata.definitions import MapGroup
-from tilemaker.processing.extractor import extract
-from tilemaker.providers.fits import PullableTile
-
-from ..processing.renderer import Renderer, RenderOptions
-
-renderer = Renderer(format="webp")
+from tilemaker.metadata.definitions import BandSummary
 
 maps_router = APIRouter(prefix="/maps", tags=["Maps and Tiles"])
 
 
 @maps_router.get(
-    "",
-    response_model=list[MapGroup],
-    summary="Get the list of map groups.",
-    description="Retrieve a list of MapGroup shaped objects, each containing a list of Maps, with a list of Bands, and finally a list of Layers.",
+    "/{map_id}/bands",
+    response_model=list[BandSummary],
+    summary="Get the list of band summaries associated with a Map.",
+    description="Retrieve a list of BandSummary objects that belong to a particular Map."
 )
-def get_maps(request: Request):
-    return [x for x in request.app.config.map_groups if x.auth(request.auth.scopes)]
-
-
-@maps_router.get(
-    "/{layer_id}/submap/{left}/{right}/{top}/{bottom}/image.{ext}",
-    summary="Generate a cut-out of the map.",
-    description="Download and extract (from the base map) a rendered cut-out. Downloads at the full resolution of the underlying map with no additional filter function.",
-)
-def get_submap(
-    layer_id: str,
-    left: float,
-    right: float,
-    top: float,
-    bottom: float,
-    ext: Literal["jpg", "webp", "png", "fits"],
-    request: Request,
-    bt: BackgroundTasks,
-    render_options: RenderOptions = Depends(RenderOptions),
-    show_grid: bool = False,
+def get_layer_summaries_of_band(
+    map_id: str,
+    request: Request
 ):
-    """
-    Get a submap of the specified band.
-    """
-
-    submap, pushables = extract(
-        layer_id=layer_id,
-        left=left,
-        right=right,
-        top=top,
-        bottom=bottom,
-        tiles=request.app.tiles,
-        grants=request.auth.scopes,
-        metadata=request.app.config,
-        show_grid=show_grid,
-    )
-
-    bt.add_task(request.app.tiles.push, pushables)
-
-    if ext == "jpg":
-        with io.BytesIO() as output:
-            renderer.render(output, submap, render_options=render_options)
-            return Response(content=output.getvalue(), media_type="image/jpg")
-    elif ext == "webp":
-        with io.BytesIO() as output:
-            renderer.render(output, submap, render_options=render_options)
-            return Response(content=output.getvalue(), media_type="image/webp")
-    elif ext == "png":
-        with io.BytesIO() as output:
-            renderer.render(output, submap, render_options=render_options)
-            return Response(content=output.getvalue(), media_type="image/png")
-    elif ext == "fits":
-        with io.BytesIO() as output:
-            hdu = fits.PrimaryHDU(submap)
-            hdu.writeto(output)
-            return Response(content=output.getvalue(), media_type="image/fits")
-
-
-def core_tile_retrieval(
-    layer: str,
-    level: int,
-    y: int,
-    x: int,
-    bt: BackgroundTasks,
-    request: Request,
-):
-    tile, pushables = request.app.tiles.pull(
-        PullableTile(layer_id=layer, x=x, y=y, level=level, grants=request.auth.scopes)
-    )
-
-    bt.add_task(request.app.tiles.push, pushables)
-
-    return tile.data
-
-
-@maps_router.get(
-    "/{layer}/{level}/{y}/{x}/tile.{ext}",
-    summary="Retrieve an individual tile.",
-    description="Individual tiles are hosted at a layer level, with them having three axes: `level`, `y`, and `x`. We support extensions of 'png', 'webp', and 'jpg'.",
-)
-def get_tile(
-    layer: str,
-    level: int,
-    y: int,
-    x: int,
-    ext: str,
-    request: Request,
-    bt: BackgroundTasks,
-    render_options: RenderOptions = Depends(RenderOptions),
-):
-    """
-    Grab an individual tile. This should be very fast, because we use
-    a composite primary key for band, level, x, and y.
-
-    Supported extensions:
-    - jpg
-    - webp
-    - png
-
-    Note: This does not support FITS tiles, as they are not
-    typically used for rendering. If you need FITS images, please
-    use the `/maps/{map}/{band}/submap/{left}/{right}/{top}/{bottom}/image.fits`
-    endpoint instead.
-    """
-
-    if render_options.flip:
-        # Flipping is really a reconfiguration of -180 < RA < 180 to 360 < RA < 0;
-        # it's a card-folding operation.
-        if level != 0:
-            # Level of zero requires no flipping apart from at the tile level.
-            midpoint = 2 ** (level)
-            if x < midpoint:
-                x = (2 ** (level) - 1) - x
-            else:
-                x = (2 ** (level) - 1) - (x - midpoint) + midpoint
-
-    if ext not in ["jpg", "webp", "png"]:
-        raise HTTPException(status_code=400, detail="Not an acceptable extension")
-
-    numpy_buf = core_tile_retrieval(
-        layer=layer,
-        level=level,
-        y=y,
-        x=x,
-        request=request,
-        bt=bt,
-    )
-
-    if numpy_buf is None:
-        raise HTTPException(status_code=404, detail="Tile not found")
-
-    with io.BytesIO() as output:
-        renderer.render(output, numpy_buf, render_options=render_options)
-        return Response(content=output.getvalue(), media_type=f"image/{ext}")
+    for map_group in request.app.config.map_groups:
+        for map in map_group.maps:
+            if (map.map_id == map_id and map_group.auth(request.auth.scopes)):
+                for band in map.bands:
+                    band_summaries = []
+                    band_summary = BandSummary(
+                        band_id=band.band_id,
+                        name=band.name,
+                        description=band.description,
+                        layer_ids=[layer.layer_id for layer in band.layers]
+                    )
+                    band_summaries.append(band_summary)
+                return band_summaries
+    return []

--- a/tilemaker/server/search.py
+++ b/tilemaker/server/search.py
@@ -1,0 +1,72 @@
+"""
+Endpoint to search map groups and its children
+"""
+from fastapi import (
+    APIRouter,
+    Request,
+    Query,
+)
+
+from tilemaker.metadata.definitions import SearchResponse
+
+
+search_router = APIRouter(prefix="/search", tags=["Search map groups"])
+    
+
+@search_router.get("", response_model=SearchResponse)
+def search_layers(request: Request, q: str = Query(..., min_length=1)):
+    raw_groups = [g.dict() for g in request.app.config.map_groups if g.auth(request.auth.scopes)]
+    result = filter_map_groups(raw_groups, q)
+
+    return SearchResponse(
+        filtered_layer_menu=result["filtered_map_groups"],
+        matched_ids=list(result["matched_ids"]),
+    )
+
+
+def match(name: str, query: str) -> bool:
+    """Case-insensitive substring match — swap in rapidfuzz here later if needed."""
+    return query.lower() in name.lower()
+
+
+def filter_map_groups(map_groups: list, query: str) -> dict:
+    matched_ids: set[str] = set()
+    filtered_groups = []
+
+    for group in map_groups:
+        # Group name matches — keep entire subtree intact
+        if match(group["name"], query):
+            matched_ids.add(group["name"])
+            filtered_groups.append(group)
+            continue
+
+        filtered_maps = []
+        for map in group.get("maps", []):
+            # Map name matches — keep entire subtree intact
+            if match(map["name"], query):
+                matched_ids.add(map["map_id"])
+                filtered_maps.append(map)
+                continue
+
+            filtered_bands = []
+            for band in map.get("bands", []):
+                # Band name matches — keep entire subtree intact
+                if match(band["name"], query):
+                    matched_ids.add(band["band_id"])
+                    filtered_bands.append(band)
+                    continue
+
+                filtered_layers = [
+                    layer for layer in band.get("layers", [])
+                    if match(layer["name"], query) and matched_ids.add(layer["layer_id"]) is None
+                ]
+                if filtered_layers:
+                    filtered_bands.append({**band, "layers": filtered_layers})
+
+            if filtered_bands:
+                filtered_maps.append({**map, "bands": filtered_bands})
+
+        if filtered_maps:
+            filtered_groups.append({**group, "maps": filtered_maps})
+
+    return {"filtered_map_groups": filtered_groups, "matched_ids": matched_ids}

--- a/tilemaker/server/search.py
+++ b/tilemaker/server/search.py
@@ -1,21 +1,23 @@
 """
 Endpoint to search map groups and its children
 """
+
 from fastapi import (
     APIRouter,
-    Request,
     Query,
+    Request,
 )
 
 from tilemaker.metadata.definitions import SearchResponse
 
-
 search_router = APIRouter(prefix="/search", tags=["Search map groups"])
-    
+
 
 @search_router.get("", response_model=SearchResponse)
 def search_layers(request: Request, q: str = Query(..., min_length=1)):
-    raw_groups = [g.dict() for g in request.app.config.map_groups if g.auth(request.auth.scopes)]
+    raw_groups = [
+        g.dict() for g in request.app.config.map_groups if g.auth(request.auth.scopes)
+    ]
     result = filter_map_groups(raw_groups, q)
 
     return SearchResponse(
@@ -36,7 +38,7 @@ def filter_map_groups(map_groups: list, query: str) -> dict:
     for group in map_groups:
         # Group name matches — keep entire subtree intact
         if match(group["name"], query):
-            matched_ids.add(group["name"])
+            matched_ids.add(group["map_group_id"])
             filtered_groups.append(group)
             continue
 
@@ -57,8 +59,10 @@ def filter_map_groups(map_groups: list, query: str) -> dict:
                     continue
 
                 filtered_layers = [
-                    layer for layer in band.get("layers", [])
-                    if match(layer["name"], query) and matched_ids.add(layer["layer_id"]) is None
+                    layer
+                    for layer in band.get("layers", [])
+                    if match(layer["name"], query)
+                    and matched_ids.add(layer["layer_id"]) is None
                 ]
                 if filtered_layers:
                     filtered_bands.append({**band, "layers": filtered_layers})

--- a/tilemaker/server/search.py
+++ b/tilemaker/server/search.py
@@ -19,8 +19,7 @@ def search_layers(request: Request, q: str = Query(..., min_length=1)):
         g.dict() for g in request.app.config.map_groups if g.auth(request.auth.scopes)
     ]
     result = request.app.config.filter_map_groups(authorized_groups, q)
-
     return SearchResponse(
-        filtered_layer_menu=result["filtered_map_groups"],
-        matched_ids=list(result["matched_ids"]),
+        filtered_layer_menu=result.filtered_layer_menu,
+        matched_ids=result.matched_ids,
     )

--- a/tilemaker/server/search.py
+++ b/tilemaker/server/search.py
@@ -15,62 +15,12 @@ search_router = APIRouter(prefix="/search", tags=["Search map groups"])
 
 @search_router.get("", response_model=SearchResponse)
 def search_layers(request: Request, q: str = Query(..., min_length=1)):
-    raw_groups = [
+    authorized_groups = [
         g.dict() for g in request.app.config.map_groups if g.auth(request.auth.scopes)
     ]
-    result = filter_map_groups(raw_groups, q)
+    result = request.app.config.filter_map_groups(authorized_groups, q)
 
     return SearchResponse(
         filtered_layer_menu=result["filtered_map_groups"],
         matched_ids=list(result["matched_ids"]),
     )
-
-
-def match(name: str, query: str) -> bool:
-    """Case-insensitive substring match — swap in rapidfuzz here later if needed."""
-    return query.lower() in name.lower()
-
-
-def filter_map_groups(map_groups: list, query: str) -> dict:
-    matched_ids: set[str] = set()
-    filtered_groups = []
-
-    for group in map_groups:
-        # Group name matches — keep entire subtree intact
-        if match(group["name"], query):
-            matched_ids.add(group["map_group_id"])
-            filtered_groups.append(group)
-            continue
-
-        filtered_maps = []
-        for map in group.get("maps", []):
-            # Map name matches — keep entire subtree intact
-            if match(map["name"], query):
-                matched_ids.add(map["map_id"])
-                filtered_maps.append(map)
-                continue
-
-            filtered_bands = []
-            for band in map.get("bands", []):
-                # Band name matches — keep entire subtree intact
-                if match(band["name"], query):
-                    matched_ids.add(band["band_id"])
-                    filtered_bands.append(band)
-                    continue
-
-                filtered_layers = [
-                    layer
-                    for layer in band.get("layers", [])
-                    if match(layer["name"], query)
-                    and matched_ids.add(layer["layer_id"]) is None
-                ]
-                if filtered_layers:
-                    filtered_bands.append({**band, "layers": filtered_layers})
-
-            if filtered_bands:
-                filtered_maps.append({**map, "bands": filtered_bands})
-
-        if filtered_maps:
-            filtered_groups.append({**group, "maps": filtered_maps})
-
-    return {"filtered_map_groups": filtered_groups, "matched_ids": matched_ids}


### PR DESCRIPTION
This updates the API in order to minimize initial load time by sending only the minimal JSON data needed for the client's layer menu and a default baselayer. Then, as a user navigates the client's layer menu, new endpoints send summaries for maps, bands, and layers that get rendered as respective children in the menu. A search endpoint also filters map groups in the server, and sends a tree and a list of matched IDs for the client's layer menu.

Note that we now only send detailed layer data when a layer is actually selected, since the data is not necessary for the layer menu itself. 